### PR TITLE
aeskeyfind added

### DIFF
--- a/cmd/brew-desc.rb
+++ b/cmd/brew-desc.rb
@@ -41,6 +41,7 @@ descriptions = {
   "advancecomp" => "Recompression utilities for .PNG, .MNG, .ZIP and .GZ files",
   "aescrypt-packetizer" => "Encrypt and decrypt using 256-bit AES encryption",
   "aescrypt" => "Program for encryption/decryption",
+  "aeskeyfind" => "Program for automatic key-finding",
   "aespipe" => "AES encryption or decryption for pipes",
   "afflib" => "Advanced Forensic Format",
   "afio" => "Creates cpio-format archives",


### PR DESCRIPTION
It’s in [homebrew/master](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/aeskeyfind.rb).

Note: I just ran a `brew desc` on the whole Homebrew repo and it was the only missing formula :+1: 